### PR TITLE
Remove JS affecting the flowchart load

### DIFF
--- a/app/templates/flowchart/flowchart.html
+++ b/app/templates/flowchart/flowchart.html
@@ -849,11 +849,6 @@ jQuery('[name="scale"]').on('change', function() {
 })
 
 jQuery(document).ready(function() {
-  setTimeout(function() {
-    jQuery('[media=print]').remove()
-    jQuery('[media=screen]').attr('media', 'all')
-  }, 100)
-
   const $body = jQuery('body')
 
 


### PR DESCRIPTION
This block made some stylesheets load twice which
lengthened the load time and caused a visual jump
when it loaded.